### PR TITLE
Avoid the giant margin

### DIFF
--- a/src/site.css
+++ b/src/site.css
@@ -3158,7 +3158,7 @@ option {
   clip: auto; }
 
 .main-content {
-  margin: 110px auto 30px;
+  margin: 20px;
   width: 90%;
   max-width: 600px; }
 


### PR DESCRIPTION
This was killing things on small resolutions. I'm sure some CSS magic could be used here to make it work on all resolutions, but this is a quick fix.

Signed-off-by: Tim Smith <tsmith@chef.io>